### PR TITLE
Send User-Agent header identifying the Client (#991)

### DIFF
--- a/elasticsearch/transport.py
+++ b/elasticsearch/transport.py
@@ -1,9 +1,11 @@
 import time
 from itertools import chain
+from platform import python_version
 
 from .connection import Urllib3HttpConnection
 from .connection_pool import ConnectionPool, DummyConnectionPool
 from .serializer import JSONSerializer, Deserializer, DEFAULT_SERIALIZERS
+from . import __versionstr__
 from .exceptions import (
     ConnectionError,
     TransportError,
@@ -334,6 +336,10 @@ class Transport(object):
             ignore = params.pop("ignore", ())
             if isinstance(ignore, int):
                 ignore = (ignore,)
+
+        if headers is None:
+            headers = {}
+        headers["user-agent"] = "elasticsearch-py/%s (Python %s)" % (__versionstr__, python_version())
 
         for attempt in range(self.max_retries + 1):
             connection = self.get_connection()

--- a/test_elasticsearch/test_transport.py
+++ b/test_elasticsearch/test_transport.py
@@ -1,11 +1,13 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 import time
+from platform import python_version
 
 from elasticsearch.transport import Transport, get_host_info
 from elasticsearch.connection import Connection
 from elasticsearch.connection_pool import DummyConnectionPool
 from elasticsearch.exceptions import ConnectionError, ImproperlyConfigured
+from elasticsearch import __versionstr__
 
 from .test_cases import TestCase
 
@@ -82,7 +84,9 @@ class TestTransport(TestCase):
         self.assertEquals(1, len(t.get_connection().calls))
         self.assertEquals(("GET", "/", {}, None), t.get_connection().calls[0][0])
         self.assertEquals(
-            {"timeout": 42, "ignore": (), "headers": None},
+            {"timeout": 42, "ignore": (), "headers": {
+                'user-agent':"elasticsearch-py/%s (Python %s)" % (__versionstr__, python_version())}
+            },
             t.get_connection().calls[0][1],
         )
 


### PR DESCRIPTION
* send user agent header identifing the client

* no need to instantiate a new var

* add python version to user-agent